### PR TITLE
release 1.0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "pay-now/paynow-woocommerce",
   "description": "WooCommerce Paynow Plugin",
   "license": "MIT",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "authors": [
     {
       "name": "mElements S.A.",

--- a/woocommerce-gateway-paynow.php
+++ b/woocommerce-gateway-paynow.php
@@ -3,7 +3,7 @@
  * Plugin Name: Pay by Paynow
  * Plugin URI: https://github.com/pay-now/paynow-woocommerce
  * Description: Accepts payments by Paynow
- * Version: 1.0.11
+ * Version: 1.0.12
  * Requires PHP: 7.1
  * Author: mElements S.A.
  * Author URI: https://www.paynow.pl
@@ -27,7 +27,7 @@ function woocommerce_gateway_paynow_init() {
 
 	define( 'WC_PAYNOW_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 	define( 'WC_PAYNOW_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
-	define( 'WC_PAYNOW_PLUGIN_VERSION', '1.0.11');
+	define( 'WC_PAYNOW_PLUGIN_VERSION', '1.0.12');
 
 	include_once dirname( __FILE__ ) . '/vendor/autoload.php';
 	require_once dirname( __FILE__ ) . '/includes/class-wc-paynow-helper.php';


### PR DESCRIPTION
**Wymagana wersja PHP 7.1 +**

[Instrukcja instalacji i konfiguracji](https://github.com/pay-now/paynow-woocommerce#spis-tre%C5%9Bci)

## Co zmieniliśmy
- Podbita wersja SDK


**Required PHP 7.1 +**

[Installation and configuration manual](https://github.com/pay-now/paynow-woocommerce/blob/master/README.EN.md#table-of-contents)

## What’s changed
- Increased SDK version
