### PR TITLE
Fix confirm-blik js

### DIFF
--- a/src/assets/js/confirm-blik.js
+++ b/src/assets/js/confirm-blik.js
@@ -13,7 +13,7 @@
 				dataType: 'json',
 				type: 'get',
 				success: function (message) {
-					if (message.payment_status !== "PENDING") {
+					if (message.payment_status !== "PENDING" && message.payment_status !== "NEW") {
 						clearInterval( pollPaymentStatus );
 						window.location.replace( message.redirect_url );
 					}


### PR DESCRIPTION
Po wybraniu opcji płatności BLIK i złożeniu zamówienia ekran oczekiwania zbyt szybko kończy sprawdzanie statusu płatności.

Dzieje się tak, ponieważ pierwsza odpowiedź statusu czasem zwraca NEW zamiast PENDING. W przypadku NEW sprawdzanie powinno być kontynuowane.

```json
{
  "order_status": "pending",
  "payment_status": "NEW",
  "redirect_url": "..."}
```
